### PR TITLE
Add GitHub Action to build and deploy web app on tag pushes

### DIFF
--- a/.github/workflows/deploy-web-on-tag.yml
+++ b/.github/workflows/deploy-web-on-tag.yml
@@ -1,0 +1,33 @@
+name: Build and Deploy Web on Tag
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Build web
+        run: flutter build web --release
+
+      - name: Deploy to Firebase Hosting
+        uses: FirebaseExtended/action-hosting-deploy@v0
+        with:
+          repoToken: '${{ secrets.GITHUB_TOKEN }}'
+          firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT }}'
+          projectId: '${{ secrets.FIREBASE_PROJECT_ID }}'
+          channelId: live


### PR DESCRIPTION
### Motivation
- Automate building the Flutter web app and deploying it to Firebase Hosting whenever a new Git tag is pushed to avoid manual releases.
- Ensure the deployed site matches the repo's `build/web` output configured in `firebase.json`.

### Description
- Add workflow file at `/.github/workflows/deploy-web-on-tag.yml` that triggers on any pushed tag (`on.push.tags: '*'`).
- The job checks out the repo, sets up Flutter (`subosito/flutter-action@v2` with `channel: stable`), runs `flutter pub get`, and runs `flutter build web --release`.
- Deploys `build/web` to Firebase Hosting using `FirebaseExtended/action-hosting-deploy@v0` and requires the `FIREBASE_SERVICE_ACCOUNT` and `FIREBASE_PROJECT_ID` repository secrets along with `GITHUB_TOKEN`.

### Testing
- Confirmed the workflow file was created and staged by running `git status --short`, which succeeded.
- Verified file contents with `sed -n '1,200p' .github/workflows/deploy-web-on-tag.yml` and `nl -ba .github/workflows/deploy-web-on-tag.yml`, both of which succeeded.
- Note that the workflow itself has not been executed in CI here; GitHub Actions will run on the next pushed tag.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b86279240832bbeb6d8b1c4f5f980)